### PR TITLE
fix: drop dead remove-snap include and correct starship toggle typo

### DIFF
--- a/roles/common/tasks/fish.yml
+++ b/roles/common/tasks/fish.yml
@@ -68,7 +68,7 @@
   ansible.builtin.stat:
     path: /usr/local/bin/starship
   register: starship_bin_stat
-  when: install_starfish | default(false)
+  when: install_starship | default(false)
 
 - name: Download Starship install script
   ansible.builtin.get_url:
@@ -76,7 +76,7 @@
     dest: /tmp/starship_install.sh
     mode: "0755"
   when:
-    - install_starfish | default(false)
+    - install_starship | default(false)
     - not (starship_bin_stat.stat.exists | default(false))
 
 - name: Install Starship fish prompt
@@ -84,7 +84,7 @@
     cmd: sh /tmp/starship_install.sh --yes
     creates: /usr/local/bin/starship
   when:
-    - install_starfish | default(false)
+    - install_starship | default(false)
     - not (starship_bin_stat.stat.exists | default(false))
   changed_when: false
 
@@ -96,7 +96,7 @@
     group: wheel
     mode: "0644"
   become: true
-  when: install_starfish | default(false)
+  when: install_starship | default(false)
 
 - name: Create user .config directory
   ansible.builtin.file:
@@ -106,7 +106,7 @@
     mode: "0755"
     state: directory
   become: true
-  when: install_starfish | default(false)
+  when: install_starship | default(false)
 
 - name: Copy fish aliases script
   ansible.builtin.copy:

--- a/roles/third-party/tasks/alacritty.yml
+++ b/roles/third-party/tasks/alacritty.yml
@@ -1,13 +1,4 @@
 ---
-- name: Remove conflicting Alacritty snap
-  ansible.builtin.include_tasks:
-    file: remove-snap.yml
-    apply:
-      tags: [third_party, alacritty]
-  vars:
-    snap_names: [alacritty]
-  tags: [third_party, alacritty]
-
 - name: Create a directory if it does not exist
   ansible.builtin.file:
     path: /home/{{ local_user }}/.config/alacritty


### PR DESCRIPTION
## Summary
Two latent bugs that were ported verbatim from the Ubuntu sibling repo and only surface on Arch/Manjaro:

- **`alacritty.yml` → missing `remove-snap.yml`**: the first task did `include_tasks: remove-snap.yml`, but that file does not exist in this repo (snap is an Ubuntu concept). Because `install_alacritty` defaults to `true`, **every default run failed** at this task. Removed the snap-removal block entirely.
- **`fish.yml` → `install_starfish` typo**: all five Starship tasks were gated on `install_starfish`, but the real toggle is `install_starship`. Setting `install_starship: true` silently did nothing. Renamed all five occurrences.

## Test plan
- [ ] `ansible-lint .` and `yamllint .` pass
- [ ] Default converge no longer fails at the Alacritty task
- [ ] `install_starship: true` actually installs Starship + templates the config