### PR TITLE
chore: remove dead vars toggles (install_packager, local_user_passwordless_sudo)

### DIFF
--- a/vars/vars.example.yml
+++ b/vars/vars.example.yml
@@ -10,7 +10,6 @@
 # User
 local_user: tharpem
 local_user_email: mtharpe@noemail.not
-local_user_passwordless_sudo: true
 
 # Services
 enable_fail2ban: true
@@ -20,7 +19,6 @@ enable_sshd: false
 local_network: ""
 
 # Extras
-install_packager: true
 install_printers: true
 
 # Third party


### PR DESCRIPTION
## Summary
Both toggles were defined in `vars/vars.example.yml` but referenced **nowhere** in any task, template, or doc (verified by grep across the whole repo):

- `install_packager` — never gated anything.
- `local_user_passwordless_sudo` — passwordless sudo is configured unconditionally via the `%wheel ... NOPASSWD` line in `system.yml`, so the toggle was a no-op.

Removing them so the vars file reflects what the playbook actually honors. Part of a cross-repo consistency pass (same change applied to the Fedora and Ubuntu siblings).

## Test plan
- [ ] `yamllint .` passes
- [ ] `ansible-playbook --syntax-check setup_workstation.yml` passes