### PR TITLE
feat(gnome): custom keyboard shortcuts + screenshot-to-clipboard helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Configures an Arch-family workstation with:
 
 - **Common packages** — developer tooling, fonts, multimedia codecs, system utilities (`roles/common`)
 - **Third-party apps** — Chrome, VS Code, Slack, Zoom, Docker, etc., gated by feature flags (`roles/third-party`)
-- **GNOME settings** — sensible dconf defaults, system-wide dark mode that also reaches legacy GTK2 and Qt apps, workspace layout (`roles/gnome`)
+- **GNOME settings** — sensible dconf defaults, system-wide dark mode that also reaches legacy GTK2 and Qt apps, workspace layout, and custom keyboard shortcuts incl. screenshot-to-clipboard helpers (`gnome_custom_keybindings` in `vars/vars.yml`) (`roles/gnome`)
 - **Printing** — CUPS with broad driver coverage (Gutenprint/foomatic/HPLIP), the system-config-printer GUI, and automatic mDNS/IPP network printer discovery (`roles/common/tasks/printers.yml`)
 - **Shell setup** — bash or fish with TPM, Starship, FiraCode Nerd Font (toggle in `vars/vars.yml`)
 - **Hardening** — fail2ban with progressive bans (on by default), ufw desktop firewall, optional sshd hardening

--- a/roles/gnome/files/area-screenshot-clip
+++ b/roles/gnome/files/area-screenshot-clip
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Area screenshot -> Wayland clipboard.
+# gnome-screenshot -c is unreliable on Wayland, so capture to a temp file
+# and push it to the clipboard with wl-copy instead.
+set -euo pipefail
+
+tmp="$(mktemp --suffix=.png)"
+trap 'rm -f "$tmp"' EXIT
+
+# -a: interactive area selection, -f: write to file (no clipboard flag)
+gnome-screenshot -a -f "$tmp"
+
+# Only copy if a selection was actually captured (user may cancel with Esc)
+if [ -s "$tmp" ]; then
+    wl-copy --type image/png < "$tmp"
+fi

--- a/roles/gnome/files/fullscreen-screenshot-clip
+++ b/roles/gnome/files/fullscreen-screenshot-clip
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Full-screen screenshot -> Wayland clipboard.
+# gnome-screenshot -c is unreliable on Wayland, so capture to a temp file
+# and push it to the clipboard with wl-copy instead.
+set -euo pipefail
+
+tmp="$(mktemp --suffix=.png)"
+trap 'rm -f "$tmp"' EXIT
+
+# No -a: capture the whole screen. -f: write to file (no clipboard flag).
+gnome-screenshot -f "$tmp"
+
+if [ -s "$tmp" ]; then
+    wl-copy --type image/png < "$tmp"
+fi

--- a/roles/gnome/tasks/keybindings.yml
+++ b/roles/gnome/tasks/keybindings.yml
@@ -1,0 +1,99 @@
+---
+# Reproduce the user's custom GNOME keyboard shortcuts so a fresh install
+# matches an existing machine without manual setup. This covers:
+#   - custom command shortcuts (1Password, file manager, screenshots)
+#   - the screenshot-to-clipboard helper scripts those shortcuts call
+# Window-switching keybindings (Alt-Tab) are set in the main dconf block.
+
+- name: Install screenshot shortcut dependencies
+  community.general.pacman:
+    name:
+      - gnome-screenshot   # capture backend used by the helper scripts
+      - wl-clipboard       # provides wl-copy for the Wayland clipboard
+    state: present
+    update_cache: true
+  become: true
+  tags: [gnome, keybindings, screenshot]
+
+- name: Ensure the user's ~/.local/bin exists
+  ansible.builtin.file:
+    path: "/home/{{ local_user }}/.local/bin"
+    state: directory
+    owner: "{{ local_user }}"
+    group: "{{ local_user }}"
+    mode: "0755"
+  become: true
+  tags: [gnome, keybindings, screenshot]
+
+- name: Install screenshot-to-clipboard helper scripts
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "/home/{{ local_user }}/.local/bin/{{ item }}"
+    owner: "{{ local_user }}"
+    group: "{{ local_user }}"
+    mode: "0755"
+  become: true
+  loop:
+    - area-screenshot-clip
+    - fullscreen-screenshot-clip
+  tags: [gnome, keybindings, screenshot]
+
+# Build the GVariant array of custom-keybinding paths (one per entry):
+# ['/org/.../custom0/', '/org/.../custom1/', ...]. Derived from the list
+# length so it always matches gnome_custom_keybindings.
+- name: Compute custom keybinding registration paths
+  ansible.builtin.set_fact:
+    gnome_ckb_paths: >-
+      ['{{ range(gnome_custom_keybindings | length) | map('string')
+           | map('regex_replace', '^', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom')
+           | map('regex_replace', '$', '/')
+           | join("', '") }}']
+  tags: [gnome, keybindings]
+
+- name: Register the custom keybinding list
+  community.general.dconf:
+    key: /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings
+    value: "{{ gnome_ckb_paths }}"
+    state: present
+  become: true
+  become_user: "{{ local_user }}"
+  tags: [gnome, keybindings]
+
+- name: Set custom keybinding names
+  community.general.dconf:
+    key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom{{ ckb_idx }}/name"
+    value: "'{{ item.name }}'"
+    state: present
+  become: true
+  become_user: "{{ local_user }}"
+  loop: "{{ gnome_custom_keybindings }}"
+  loop_control:
+    index_var: ckb_idx
+    label: "{{ item.name }}"
+  tags: [gnome, keybindings]
+
+- name: Set custom keybinding commands
+  community.general.dconf:
+    key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom{{ ckb_idx }}/command"
+    value: "'{{ item.command }}'"
+    state: present
+  become: true
+  become_user: "{{ local_user }}"
+  loop: "{{ gnome_custom_keybindings }}"
+  loop_control:
+    index_var: ckb_idx
+    label: "{{ item.name }}"
+  tags: [gnome, keybindings]
+
+- name: Set custom keybinding bindings
+  community.general.dconf:
+    key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom{{ ckb_idx }}/binding"
+    value: "'{{ item.binding }}'"
+    state: present
+  become: true
+  become_user: "{{ local_user }}"
+  loop: "{{ gnome_custom_keybindings }}"
+  loop_control:
+    index_var: ckb_idx
+    label: "{{ item.name }}"
+  tags: [gnome, keybindings]

--- a/roles/gnome/tasks/main.yml
+++ b/roles/gnome/tasks/main.yml
@@ -120,3 +120,10 @@
   ansible.builtin.import_tasks: extensions.yml
   when: not is_container | default(false)
   tags: [gnome, extensions]
+
+- name: Reproduce custom keyboard shortcuts and screenshot helpers
+  ansible.builtin.import_tasks: keybindings.yml
+  when:
+    - not is_container | default(false)
+    - gnome_custom_keybindings | default([]) | length > 0
+  tags: [gnome, keybindings]

--- a/vars/vars.example.yml
+++ b/vars/vars.example.yml
@@ -52,6 +52,25 @@ gnome_extensions:
   - power-profile-switcher@fthx
   - auto-select-headset@krocg
 
+# Custom GNOME keyboard shortcuts, reproduced on every run so a fresh install
+# matches your existing setup. Each entry maps a key binding to a command.
+# The screenshot entries call helper scripts the gnome role installs to
+# ~/.local/bin (they capture to the Wayland clipboard via wl-copy). Leave the
+# list empty to skip custom shortcuts entirely.
+gnome_custom_keybindings:
+  - name: "1Password Quick Access"
+    binding: "<Shift><Control>space"
+    command: "/usr/bin/1password --quick-access"
+  - name: "Open File Manager"
+    binding: "<Super>e"
+    command: "nautilus --new-window"
+  - name: "Area Screenshot (to clipboard)"
+    binding: "<Shift><Alt>4"
+    command: "/home/{{ local_user }}/.local/bin/area-screenshot-clip"
+  - name: "Fullscreen Screenshot (to clipboard)"
+    binding: "<Shift><Alt>3"
+    command: "/home/{{ local_user }}/.local/bin/fullscreen-screenshot-clip"
+
 # python3
 ansible_python_interpreter: /usr/bin/python3
 


### PR DESCRIPTION
## Summary
- Ports the GNOME custom-keybindings feature from the Fedora/Ubuntu repos for cross-distro parity.
- Adds `gnome_custom_keybindings` to `vars/vars.example.yml`: 1Password Quick Access, Open File Manager, and area + fullscreen screenshot-to-clipboard.
- Installs two helper scripts to `~/.local/bin` that capture with `gnome-screenshot` and push the PNG to the Wayland clipboard via `wl-copy` (`gnome-screenshot -c` is unreliable on Wayland). Scripts are byte-identical to the Fedora/Ubuntu copies.
- New `roles/gnome/tasks/keybindings.yml` installs `gnome-screenshot` + `wl-clipboard` via **`community.general.pacman`** (the Arch-specific divergence from Fedora's dnf / Ubuntu's apt), drops the helper scripts, and registers the bindings under `settings-daemon/plugins/media-keys/custom-keybindings/`.
- Wired into `roles/gnome/tasks/main.yml` after the extensions import, guarded by `not is_container` and a non-empty `gnome_custom_keybindings` list.

## Notes
- The only intended difference from the Fedora/Ubuntu implementation is the package-manager module (pacman); the var block, helper scripts, and dconf registration logic are identical.
- **1Password path:** the repo installs 1Password via the `1password` AUR package, and the binding calls `/usr/bin/1password --quick-access`. This matches the vendor-standard Linux layout (`/opt/1Password` + `/usr/bin/1password` symlink) used by the working Fedora/Ubuntu entries. I could not directly fetch the AUR PKGBUILD to 100% confirm the symlink (AUR/wiki are behind Anubis bot-protection); if it differs on a given box, only this one binding is affected and the path is a one-line fix.
- **Out of scope:** local (hand-written) GNOME extensions parity — that's a separate Ubuntu-only feature and was not part of the approved keybindings port.
- Branched from `main`, so it does not include the unmerged bug-fix (#8) or var-cleanup (#9) PRs. Hunks don't overlap, so the merges are independent.

## Test plan
- [ ] `ansible-playbook setup_workstation.yml --tags gnome,keybindings --check` on an Arch-family box
- [ ] Confirm `~/.local/bin/{area,fullscreen}-screenshot-clip` are installed mode 0755
- [ ] Verify the four shortcuts appear in Settings → Keyboard → Custom Shortcuts
- [ ] Trigger each screenshot binding and paste into an app to confirm the clipboard image
- [ ] Confirm `<Shift><Control>space` opens 1Password Quick Access