### PR TITLE
feat: add Claude Desktop parity (claude-desktop-appimage AUR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ All toggles live in `vars/vars.yml`. The most useful ones:
 | `install_gcloud` | `false` | Google Cloud SDK (AUR) + kubectl |
 | `install_ansible` | `false` | Ansible (pacman) for running playbooks locally |
 | `install_claude` | `true` | Claude Code CLI (official installer to `~/.local/bin`) |
+| `install_claude_desktop` | `true` | Claude Desktop + cowork (AUR `claude-desktop-appimage`; bubblewrap sandbox — Arch permits unprivileged userns, so no AppArmor profile needed) |
 | `install_kubectl` | `true` | kubectl (pacman) — standalone, separate from `install_gcloud` |
 | `install_fish` | `true` | Fish shell + Pure prompt + Fisher |
 | `install_bash` | `false` | Bash dotfiles |

--- a/roles/third-party/tasks/claude-desktop.yml
+++ b/roles/third-party/tasks/claude-desktop.yml
@@ -1,0 +1,25 @@
+---
+# Claude Desktop has no official Linux build. On the Arch family it's packaged
+# from the community aaddrick/claude-desktop-debian project as the
+# `claude-desktop-appimage` AUR package, which wraps the upstream Windows build
+# in an Electron AppImage. The AppImage launches Electron with --no-sandbox
+# (an upstream AppImage limitation, separate from the cowork sandbox below).
+#
+# cowork uses bubblewrap (bwrap) as its sandbox backend. Unlike Ubuntu 23.10+,
+# the Arch family permits unprivileged user namespaces out of the box, so no
+# AppArmor workaround is needed here — installing bubblewrap is enough.
+- name: Install Claude Desktop (claude-desktop-appimage) from the AUR
+  ansible.builtin.command:
+    cmd: "{{ common_aur_helper }} -S --noconfirm --needed claude-desktop-appimage"
+  become: true
+  become_user: "{{ local_user }}"
+  register: claude_desktop_install
+  changed_when: "'Nothing to do' not in claude_desktop_install.stdout"
+  tags: [third_party, claude-desktop]
+
+- name: Install bubblewrap for the cowork sandbox backend
+  community.general.pacman:
+    name: bubblewrap
+    state: present
+  become: true
+  tags: [third_party, claude-desktop, cowork]

--- a/roles/third-party/tasks/main.yml
+++ b/roles/third-party/tasks/main.yml
@@ -55,6 +55,10 @@
   ansible.builtin.import_tasks: claude.yml
   when: install_claude | default(false)
 
+- name: Setup Claude Desktop
+  ansible.builtin.import_tasks: claude-desktop.yml
+  when: install_claude_desktop | default(false)
+
 - name: Setup kubectl
   ansible.builtin.import_tasks: kubectl.yml
   when: install_kubectl | default(false)

--- a/vars/vars.example.yml
+++ b/vars/vars.example.yml
@@ -42,6 +42,7 @@ install_starship: false
 install_nerd_font: true
 install_eza: true
 install_claude: true
+install_claude_desktop: true
 install_kubectl: true
 
 # GNOME Shell extensions to install + enable. UUIDs must match


### PR DESCRIPTION
## Summary
- Adds Claude Desktop parity with the Fedora and Ubuntu sibling repos.
- New `roles/third-party/tasks/claude-desktop.yml` installs the community **`claude-desktop-appimage`** AUR package (via the auto-detected AUR helper) plus **bubblewrap** for the cowork sandbox backend.
- Gated behind a new **`install_claude_desktop`** toggle (default `true`), separate from `install_claude` (Claude Code).
- Wired into `third-party/tasks/main.yml`, added to `vars/vars.example.yml`, documented in the README feature-flag table.

## Why no AppArmor profile (unlike Ubuntu)
On Ubuntu 23.10+ the Ubuntu PR (#4) ships a targeted `/etc/apparmor.d/bwrap` profile because `apparmor_restrict_unprivileged_userns=1` blocks bwrap's user namespaces. The Arch family permits unprivileged user namespaces out of the box, so no such workaround is needed here — installing `bubblewrap` is enough.

## Notes
- The AppImage launches Electron with `--no-sandbox` (an upstream AppImage limitation, independent of cowork's bubblewrap sandbox).
- `claude-desktop-appimage` verified present in the AUR (maintainer `mathys-lopinto`, not flagged out-of-date) at time of writing.
- Branch is based on `origin/main`, so it does not include the unmerged bug-fix / var-cleanup / keybindings branches; hunks don't overlap, so merges auto-resolve.

## Test plan
- [x] `ansible-playbook --syntax-check setup_workstation.yml` passes
- [x] YAML parses clean
- [ ] Converge on a non-container host with `install_claude_desktop: true` and confirm Claude Desktop + cowork launch