### PR TITLE
fix(gnome): capture screenshots via xdg-desktop-portal on GNOME 50

### DIFF
--- a/roles/gnome/files/area-screenshot-clip
+++ b/roles/gnome/files/area-screenshot-clip
@@ -1,16 +1,4 @@
 #!/usr/bin/env bash
-# Area screenshot -> Wayland clipboard.
-# gnome-screenshot -c is unreliable on Wayland, so capture to a temp file
-# and push it to the clipboard with wl-copy instead.
-set -euo pipefail
-
-tmp="$(mktemp --suffix=.png)"
-trap 'rm -f "$tmp"' EXIT
-
-# -a: interactive area selection, -f: write to file (no clipboard flag)
-gnome-screenshot -a -f "$tmp"
-
-# Only copy if a selection was actually captured (user may cancel with Esc)
-if [ -s "$tmp" ]; then
-    wl-copy --type image/png < "$tmp"
-fi
+# Area screenshot -> Wayland clipboard. Thin wrapper over the shared
+# portal-screenshot-clip core (the only capture path GNOME 50 permits).
+exec "$HOME/.local/bin/portal-screenshot-clip" --interactive

--- a/roles/gnome/files/fullscreen-screenshot-clip
+++ b/roles/gnome/files/fullscreen-screenshot-clip
@@ -1,15 +1,4 @@
 #!/usr/bin/env bash
-# Full-screen screenshot -> Wayland clipboard.
-# gnome-screenshot -c is unreliable on Wayland, so capture to a temp file
-# and push it to the clipboard with wl-copy instead.
-set -euo pipefail
-
-tmp="$(mktemp --suffix=.png)"
-trap 'rm -f "$tmp"' EXIT
-
-# No -a: capture the whole screen. -f: write to file (no clipboard flag).
-gnome-screenshot -f "$tmp"
-
-if [ -s "$tmp" ]; then
-    wl-copy --type image/png < "$tmp"
-fi
+# Full-screen screenshot -> Wayland clipboard. Thin wrapper over the shared
+# portal-screenshot-clip core (the only capture path GNOME 50 permits).
+exec "$HOME/.local/bin/portal-screenshot-clip" --fullscreen

--- a/roles/gnome/files/portal-screenshot-clip
+++ b/roles/gnome/files/portal-screenshot-clip
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Screenshot -> Wayland clipboard via xdg-desktop-portal (GNOME 50 / Wayland).
+
+gnome-screenshot and the raw org.gnome.Shell.Screenshot D-Bus API are both dead
+on GNOME 50 (empty file / AccessDenied). The xdg-desktop-portal Screenshot
+interface is the only sanctioned capture path.
+
+Usage: portal-screenshot-clip [--interactive | --fullscreen]
+  --interactive  show GNOME's area/window/screen picker (default)
+  --fullscreen   grab the whole screen with no selector
+"""
+import os
+import sys
+import urllib.parse
+import urllib.request
+import subprocess
+
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, GLib
+
+interactive = "--fullscreen" not in sys.argv
+
+BUS_NAME = "org.freedesktop.portal.Desktop"
+OBJ_PATH = "/org/freedesktop/portal/desktop"
+SCREENSHOT_IFACE = "org.freedesktop.portal.Screenshot"
+REQUEST_IFACE = "org.freedesktop.portal.Request"
+
+bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+loop = GLib.MainLoop()
+result = {"uri": None}
+
+# Portal replies asynchronously on a Request object whose path it returns.
+# A unique token lets us predict that path and subscribe before the call.
+token = "shotclip" + str(os.getpid())
+sender = bus.get_unique_name()[1:].replace(".", "_")
+request_path = f"/org/freedesktop/portal/desktop/request/{sender}/{token}"
+
+
+def on_response(_conn, _sender, _path, _iface, _signal, params):
+    response_code, results = params.unpack()
+    if response_code == 0:  # 0 = success; 1 = user cancelled; 2 = error
+        result["uri"] = results.get("uri")
+    loop.quit()
+
+
+bus.signal_subscribe(
+    BUS_NAME, REQUEST_IFACE, "Response", request_path, None,
+    Gio.DBusSignalFlags.NONE, on_response,
+)
+
+options = {
+    "handle_token": GLib.Variant("s", token),
+    "interactive": GLib.Variant("b", interactive),
+}
+bus.call_sync(
+    BUS_NAME, OBJ_PATH, SCREENSHOT_IFACE, "Screenshot",
+    GLib.Variant("(sa{sv})", ("", options)),
+    GLib.VariantType("(o)"), Gio.DBusCallFlags.NONE, -1, None,
+)
+
+loop.run()
+
+uri = result["uri"]
+if not uri:
+    sys.exit(0)  # cancelled -> no-op, leave clipboard untouched
+
+path = urllib.request.url2pathname(urllib.parse.urlparse(uri).path)
+with open(path, "rb") as fh:
+    subprocess.run(["wl-copy", "--type", "image/png"], stdin=fh, check=True)

--- a/roles/gnome/tasks/keybindings.yml
+++ b/roles/gnome/tasks/keybindings.yml
@@ -8,8 +8,12 @@
 - name: Install screenshot shortcut dependencies
   community.general.pacman:
     name:
-      - gnome-screenshot   # capture backend used by the helper scripts
-      - wl-clipboard       # provides wl-copy for the Wayland clipboard
+      # gnome-screenshot is dead on GNOME 50 (the org.gnome.Shell.Screenshot
+      # D-Bus API now returns AccessDenied and it writes a 0-byte file), so the
+      # helper captures via the xdg-desktop-portal Screenshot interface instead.
+      - python-gobject            # PyGObject (Gio/GLib) for the portal D-Bus call
+      - xdg-desktop-portal-gnome  # GNOME backend implementing the Screenshot portal
+      - wl-clipboard              # provides wl-copy for the Wayland clipboard
     state: present
     update_cache: true
   become: true
@@ -34,8 +38,9 @@
     mode: "0755"
   become: true
   loop:
-    - area-screenshot-clip
-    - fullscreen-screenshot-clip
+    - portal-screenshot-clip      # shared core: drives the portal Screenshot call
+    - area-screenshot-clip        # wrapper -> core --interactive
+    - fullscreen-screenshot-clip  # wrapper -> core --fullscreen
   tags: [gnome, keybindings, screenshot]
 
 # Build the GVariant array of custom-keybinding paths (one per entry):


### PR DESCRIPTION
## Why
`gnome-screenshot` is **dead on GNOME 50**. The `org.gnome.Shell.Screenshot` D-Bus API it relies on now returns `AccessDenied`, so it exits 0 while writing a **0-byte PNG** — the clipboard copy gets nothing.

## What
- New shared core `portal-screenshot-clip` drives the **xdg-desktop-portal `Screenshot`** interface (the only sanctioned capture path on GNOME 50), then `wl-copy`s the result.
- `area-screenshot-clip` / `fullscreen-screenshot-clip` become thin wrappers passing `--interactive` / `--fullscreen`.
- Keybinding var values unchanged (script names preserved).

Mirrors the Fedora fix (mtharpe/ansible-fedora-workstation-base#9), already merged and verified on Fedora 44 / GNOME 50.2 / Wayland.

**Dep swap:** drop `gnome-screenshot`, add `python-gobject` + `xdg-desktop-portal-gnome` (pacman).